### PR TITLE
return number of seconds waited

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -33,7 +33,7 @@ export default function wyt(turnsPerInterval: number, interval: number) {
     availableTurns: turnsPerInterval,
   };
 
-  async function waitTurn(turns?: number = 1): Promise<void> {
+  async function waitTurn(turns?: number = 1): Promise<number> {
     if (turns > turnsPerInterval) {
       throw new Error('Turns can not be greater than the number of turns per interval');
     }
@@ -45,6 +45,7 @@ export default function wyt(turnsPerInterval: number, interval: number) {
 
     await sleep(wait);
     state.availableTurns -= turns;
+    return wait;
   }
 
   return waitTurn;


### PR DESCRIPTION
👋 Hey @maxkueng, just found this library, love how simple and straightforward it is!

Have you given any thought to the return value of the `waitTurn()` function? For logging purposes, it would be really useful to get back whether the rate limiter actually did anything or not, and if so, how long did we wait?

Happy to add some info to the README & a test, if this is something you'd like to move forward on.