### PR TITLE
Add test and fix issue with long delay between bundles of requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ type State = {
 function reload(requestsPerInterval: number, interval: number, state: State): State {
   const throughput = requestsPerInterval / interval;
   const now = Date.now();
-  const reloadTime = Math.min(now - state.lastReload, interval);
+  const reloadTime = now - state.lastReload;
   const reloadedRequests = reloadTime * throughput;
   const newAvalableRequests = state.availableRequests + reloadedRequests;
 

--- a/test/wyt.js
+++ b/test/wyt.js
@@ -150,7 +150,7 @@ test('throw if taking more turns per take than turnsperInterval', async (t) => {
   await t.throwsAsync(() => waitTurn(3));
 });
 
-test('2 per second in parallel, after different timeoutss', async (t) => {
+test('2 per second in parallel, after different timeouts', async (t) => {
   const rpi = 2;
   const interval = 1000;
   const waitTurn = wyt(rpi, interval);
@@ -182,4 +182,5 @@ test('2 per second in parallel, after different timeoutss', async (t) => {
   await batch();
   // ensure that wyt won't next try to overprocess after a long wait
   await new Promise((resolve) => setTimeout(resolve, 3500));
+  await batch();
 });

--- a/test/wyt.js
+++ b/test/wyt.js
@@ -150,13 +150,13 @@ test('throw if taking more turns per take than turnsperInterval', async (t) => {
   await t.throwsAsync(() => waitTurn(3));
 });
 
-test('2 per second in parallel, twice', async (t) => {
-  const timer = createTimer();
+test('2 per second in parallel, after different timeoutss', async (t) => {
   const rpi = 2;
   const interval = 1000;
   const waitTurn = wyt(rpi, interval);
 
   async function batch() {
+    const timer = createTimer();
     const promises = [
       waitTurn(),
       waitTurn(),
@@ -177,6 +177,9 @@ test('2 per second in parallel, twice', async (t) => {
     t.true(roughly(t5, 3 * (interval / rpi)));
   }
   await batch();
-  await new Promise((resolve) => setTimeout(resolve, 100));
+  // let enough time for wyt to think the previous batch has enough processed
+  await new Promise((resolve) => setTimeout(resolve, 1000));
   await batch();
+  // ensure that wyt won't next try to overprocess after a long wait
+  await new Promise((resolve) => setTimeout(resolve, 3500));
 });

--- a/test/wyt.js
+++ b/test/wyt.js
@@ -1,3 +1,4 @@
+/** @type {typeof import('ava').default} */
 const test = require('ava');
 const wyt = require('../dist');
 
@@ -147,4 +148,35 @@ test('throw if taking more turns per take than turnsperInterval', async (t) => {
   const waitTurn = wyt(2, 10);
   await t.notThrowsAsync(() => waitTurn(2));
   await t.throwsAsync(() => waitTurn(3));
+});
+
+test('2 per second in parallel, twice', async (t) => {
+  const timer = createTimer();
+  const rpi = 2;
+  const interval = 1000;
+  const waitTurn = wyt(rpi, interval);
+
+  async function batch() {
+    const promises = [
+      waitTurn(),
+      waitTurn(),
+      waitTurn(),
+      waitTurn(),
+      waitTurn(),
+    ];
+
+    const [t1, t2, t3, t4, t5] = await Promise.all(promises);
+    t.true(roughly(3 * (interval / rpi), timer()));
+
+    t.log([t1, t2, t3, t4, t5]);
+
+    t.true(roughly(t1, 0 * (interval / rpi)));
+    t.true(roughly(t2, 0 * (interval / rpi)));
+    t.true(roughly(t3, 1 * (interval / rpi)));
+    t.true(roughly(t4, 2 * (interval / rpi)));
+    t.true(roughly(t5, 3 * (interval / rpi)));
+  }
+  await batch();
+  await new Promise((resolve) => setTimeout(resolve, 100));
+  await batch();
 });


### PR DESCRIPTION
I found a strange bug that's happening in production with rate limiting large sets of requests that come in. This test case isolates and reproduces the issue